### PR TITLE
Use any available port for the test server

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -22,8 +22,9 @@ SKIP: {
 
     use_ok('REST::Client');
 
-    my $port = 7657;
-    my $pid  = REST::Client::TestServer->new($port)->background();
+    my $server = REST::Client::TestServer->new(0);
+    my $port   = $server->port;
+    my $pid    = $server->background();
 
     eval {
 


### PR DESCRIPTION
This should fix RT#119829.

Note that it depends on bestpractical/http-server-simple#12 being merged.