### PR TITLE
use LWP::UA's default_header to add client headers

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -2,6 +2,7 @@ name              = REST-Client
 main_module       = lib/REST/Client.pm
 author            = Miles Crawford <mcrawfor@cpan.org>
 author            = Kevin L. Kane <kkane@cpan.org>
+author            = Mark Gardner <mjgardner@cpan.org>
 license           = Perl_5
 copyright_holder  = Miles Crawford
 copyright_year    = 2008

--- a/lib/REST/Client.pm
+++ b/lib/REST/Client.pm
@@ -81,7 +81,7 @@ use constant TRUE => 1;
 use constant FALSE => 0;
 
 use URI;
-use LWP::UserAgent;
+use LWP::UserAgent 5.800;    # for default_headers
 use Carp qw(croak carp);
 
 =head2 Construction and setup
@@ -184,13 +184,8 @@ Add a custom header to any requests made by this client.
 =cut
 
 sub addHeader {
-    my $self = shift;
-    my $header = shift;
-    my $value = shift;
-    
-    my $headers = $self->{'_headers'} || {};
-    $headers->{$header} = $value;
-    $self->{'_headers'} = $headers;
+    my ( $self, $header, $value ) = @_;
+    $self->getUseragent->default_header( $header => $value );
     return;
 }
 
@@ -345,11 +340,6 @@ sub request {
         $req->header('Content-Length', length($content));
     }else{
         $req->header('Content-Length', 0);
-    }
-
-    my $custom_headers = $self->{'_headers'} || {};
-    for my $header (keys %$custom_headers){
-        $req->header($header, $custom_headers->{$header});
     }
 
     for my $header (keys %$headers){

--- a/t/addHeader.t
+++ b/t/addHeader.t
@@ -1,0 +1,39 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More tests => 1;
+use Test::Deep;
+use Test::Exception;
+use REST::Client;
+
+my $client = REST::Client->new();
+my $ua     = $client->getUseragent();
+
+# snapshot client's default user agent headers
+my %default;
+$ua->default_headers->scan( sub { push @{ $default{ $_[0] } }, $_[1] } );
+
+# add some headers
+my %new = (
+    'X-Foo' => 'hello',
+    'X-Bar' => [qw(one two three)],
+);
+while ( my ( $field, $value ) = each %new ) {
+    $client->addHeader( $field, $value );
+}
+
+# build expected default headers, convert scalars to arrayrefs to ease test
+my %expected = ( %default, %new );
+for ( grep { ref $expected{$_} ne q{} } keys %expected ) {
+    $expected{$_} = [ $expected{$_} ];
+}
+
+# check the UA has everything we expect
+cmp_deeply(
+    $ua->default_headers,
+    listmethods(
+        map { [ header => $_ ] => $expected{$_} } keys %expected,
+    ),
+    'user agent default_headers updated by addHeader calls',
+);


### PR DESCRIPTION
By using [LWP::UserAgent's `default_header`](https://metacpan.org/release/OALDERS/libwww-perl-6.67/view/lib/LWP/UserAgent.pm#default_header) method in `REST::Client::addHeader` instead of adding headers to every request, downstream consumers of modules like [JIRA::REST](https://metacpan.org/pod/JIRA::REST) can call, for example, `$jira->rest_client->getUseragent->default_headers` to see any set headers without violating encapsulation of the REST::Client object.

This change also explicitly requires [LWP::UserAgent v5.800](https://metacpan.org/release/GAAS/libwww-perl-5.800/view/lib/LWP/UserAgent.pm) (released 2004-06-16) or later as that was the version that [added `default_header`](https://metacpan.org/release/OALDERS/libwww-perl-6.67/changes#L939-942).