### PR TITLE
Allow headers to be deleted

### DIFF
--- a/lib/REST/Client.pm
+++ b/lib/REST/Client.pm
@@ -194,6 +194,23 @@ sub addHeader {
     return;
 }
 
+=head3  deleteHeader ( $header_name )
+
+Remove a custom header from requests made by this client.
+
+=cut
+
+sub deleteHeader {
+    my $self = shift;
+    my $header = shift;
+
+    my $headers = $self->{'_headers'} || {};
+    delete $headers->{$header} if(exists($headers->{$header}));
+    $self->{'_headers'} = $headers;
+    return;
+}
+
+
 =head3 buildQuery ( [...] )
 
 A convienience wrapper around URI::query_form for building query strings from a


### PR DESCRIPTION
Adds a deleteHeader() function that will completely remove a header field previously added using addHeader(). I've run into some situations where this is a useful feature to have. For example, when interacting with GitLab's API I need to add a 'Sudo' header for some operations, but want to remove the 'Sudo' header for other requests through the same REST::Client object.